### PR TITLE
Add remote raiding

### DIFF
--- a/RaidBot/BusinessLogic/Raids/RaidService.cs
+++ b/RaidBot/BusinessLogic/Raids/RaidService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using System.Globalization;
 using Discord;
@@ -37,34 +38,39 @@ namespace RaidBot.BusinessLogic.Raids {
          raid.Users.Add(User.FromIUser(user, guests));
       }
 
-      public ModuleResult JoinRaid(string raidName, IUser forUser, int guests, IUser requestUser = null) {
+      public ModuleResult JoinRaid(string raidName, IUser forUser, int guests, bool isRemote, IUser requestUser = null) {
 
          ModuleResult result = new ModuleResult();
 
          var raids = _raidFileService.GetRaidsFromFile().Where(a => a.Name.Equals(raidName, StringComparison.CurrentCultureIgnoreCase));
 
          if (raids.Count() == 1) {
-            bool success = AddUserToRaidIfNotExists(raids.Single(), forUser, guests);
+            bool success = AddUserToRaidIfNotExists(raids.Single(), forUser, guests, isRemote);
 
             if (success) {
                result.Success = true;
+
+               result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
+               string withGuests = guests == 0 ? string.Empty : $"with {guests} guest{(guests == 1 ? "" : "s")}";
+               string asRemoteAttendee = isRemote ? " as a remote attendee" : string.Empty;
+
                if (requestUser != null) {
-                  result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
-                  string withGuests = guests == 0 ? string.Empty : $"with {guests} guest{(guests == 1 ? "" : "s")}";
+                  var forUserUsername = (forUser as IGuildUser).Nickname ?? forUser.Username;
+                  var requestUserUsername = (requestUser as IGuildUser).Nickname ?? requestUser.Username;
+
                   result.RequesterUserBuilder
                      .WithTitle($"Raid: {raidName}")
-                     .WithDescription($"You have added {forUser.Username} to the raid {withGuests}");
+                     .WithDescription($"You have added {forUserUsername} to the raid{asRemoteAttendee} {withGuests}");
 
                   result.ReferenceUserBuilder = EmbedBuilderHelper.GreenBuilder();
                   result.ReferenceUserBuilder
                      .WithTitle($"Raid: {raidName}")
-                     .WithDescription($"You have been added to the raid by {requestUser.Username} {withGuests}");
+                     .WithDescription($"You have been added to the raid{asRemoteAttendee} by {requestUserUsername} {withGuests}");
                }
                else {
-                  result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
                   result.RequesterUserBuilder
                      .WithTitle($"Raid: {raidName}")
-                     .WithDescription($"You have been added to the raid");
+                     .WithDescription($"You have been added to the raid{asRemoteAttendee}");
                }
             }
             else {
@@ -110,7 +116,7 @@ namespace RaidBot.BusinessLogic.Raids {
                allRaids.Single(a => a.Equals(raid)).RaidBossSpriteUrl = raidBossSpriteUrl;
                _raidFileService.PushRaidsToFile(allRaids);
 
-               string raidBossMessage = oldRaidBossId == 0 ? $"Raidboss has been changed to {raidBossName}" : $"Raidboss has been changed from {raid.RaidBossName} to {raidBossName}";
+               string raidBossMessage = oldRaidBossId == 0 ? $"Raid boss has been changed to {raidBossName}" : $"Raid boss has been changed from {raid.RaidBossName} to {raidBossName}";
 
                result.Success = true;
                result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
@@ -120,7 +126,7 @@ namespace RaidBot.BusinessLogic.Raids {
                   .WithThumbnailUrl(raidBossSpriteUrl);
             }
             else {
-               result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Only the leader can change the raidboss");
+               result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Only the leader can change the raid boss");
             }
          }
          else if (raids.Count() == 0) {
@@ -149,7 +155,7 @@ namespace RaidBot.BusinessLogic.Raids {
             result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Could not find the user in that raid");
          }
          else {
-            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Somthing went wrong");
+            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Something went wrong");
          }
          return result;
       }
@@ -196,11 +202,13 @@ namespace RaidBot.BusinessLogic.Raids {
 
          var raidsFiltered = raids.Where(a => a.Users.Any(b => b.Equals(User.FromIUser(user))));
 
+         var username = (user as IGuildUser).Nickname ?? user.Username;
+
          if (raidsFiltered.Count() == 0) {
-            return EmbedBuilderHelper.ErrorBuilder($"{user.Username} is not attending any raids yet");
+            return EmbedBuilderHelper.ErrorBuilder($"{username} is not attending any raids yet");
          }
          else {
-            return EmbedBuilderHelper.RaidEmbedBuilder($"{user.Username} is attending:", raidsFiltered);
+            return EmbedBuilderHelper.RaidEmbedBuilder($"{username} is attending:", raidsFiltered);
          }
 
       }
@@ -473,15 +481,18 @@ namespace RaidBot.BusinessLogic.Raids {
                   .WithDescription($"Added {guests} guest{(guests == 1 ? "" : "s")}");
             }
             else {
+               var userToAddGuestsUsername = (userToAddGuests as IGuildUser).Nickname ?? userToAddGuests.Username;
+               var requestUserUsername = (requestUser as IGuildUser).Nickname ?? requestUser.Username;
+
                result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
                result.RequesterUserBuilder
                   .WithTitle($"Raid: {raidName}")
-                  .WithDescription($"Added {guests} guest{(guests == 1 ? "" : "s")} for {userToAddGuests.Username}");
+                  .WithDescription($"Added {guests} guest{(guests == 1 ? "" : "s")} for {userToAddGuestsUsername}");
 
                result.ReferenceUserBuilder = EmbedBuilderHelper.GreenBuilder();
                result.ReferenceUserBuilder
                   .WithTitle($"Raid: {raidName}")
-                  .WithDescription($"{requestUser.Username} has added {guests} guest{(guests == 1 ? "" : "s")} to the raid for you");
+                  .WithDescription($"{requestUserUsername} has added {guests} guest{(guests == 1 ? "" : "s")} to the raid for you");
              }
          }
          else if (raids.Count() == 0) {
@@ -526,16 +537,98 @@ namespace RaidBot.BusinessLogic.Raids {
          return EmbedBuilderHelper.RaidEmbedBuilder("All current raids:", raids);
       }
 
+      public ModuleResult ChangeAttendanceMode(string raidName, string attendanceMode, IUser requesterUser, IUser userToUpdate) {
+         var result = new ModuleResult();
+         var raids = _raidFileService.GetRaidsFromFile().Where(a => a.Name.Equals(raidName, StringComparison.CurrentCultureIgnoreCase));
+
+         if (raids.Count() == 1) {
+            string[] validModes = { "inperson", "in-person", "remote" };
+            if (Array.Exists(validModes, el => el == attendanceMode)) {
+               var raid = raids.Single();
+
+               if (userToUpdate == null) {
+                  raid.Users.Single(a => a.Equals(User.FromIUser(requesterUser))).IsRemoteAttendee = (attendanceMode == "remote");
+                  UpdateRaidWithDifferentUsers(raid);
+                  result.Success = true;
+
+                  result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
+                  result.RequesterUserBuilder
+                     .WithTitle($"Raid: {raidName}")
+                     .WithDescription($"Updated attendance mode to {attendanceMode}");
+               }
+               else {
+                  raid.Users.Single(a => a.Equals(User.FromIUser(userToUpdate))).IsRemoteAttendee = (attendanceMode == "remote");
+                  UpdateRaidWithDifferentUsers(raid);
+                  result.Success = true;
+
+                  var userToUpdateUsername = (userToUpdate as IGuildUser).Nickname ?? userToUpdate.Username;
+                  var requesterUserUsername = (requesterUser as IGuildUser).Nickname ?? requesterUser.Username;
+
+                  result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
+                  result.RequesterUserBuilder
+                     .WithTitle($"Raid: {raidName}")
+                     .WithDescription($"Updated attendance mode to {attendanceMode} for {userToUpdateUsername}");
+
+                  result.ReferenceUserBuilder = EmbedBuilderHelper.GreenBuilder();
+                  result.ReferenceUserBuilder
+                     .WithTitle($"Raid: {raidName}")
+                     .WithDescription($"{requesterUserUsername} has updated your attendance mode to {attendanceMode}");
+               }
+            }
+            else {
+               result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Invalid mode. Accepted modes are inperson and remote");
+            }
+         }
+         else if (raids.Count() == 0) {
+            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Cannot find raid");
+         }
+         else {
+            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Unknown Error");
+         }
+         return result;
+      }
+
+      public ModuleResult GetInvitesString(string raidName) {
+
+         var result = new ModuleResult();
+         var raids = _raidFileService.GetRaidsFromFile().Where(a => a.Name.Equals(raidName, StringComparison.CurrentCultureIgnoreCase));
+
+         if (raids.Count() == 1) {
+            var raid = raids.Single();
+            List<User> remoteUsers = raid.Users.Skip(1).Where(user => user.IsRemoteAttendee).ToList();
+            StringBuilder inviteString = new StringBuilder();
+
+            if (remoteUsers.Count() > 0) {
+               inviteString.Append($"{remoteUsers.First().Username}");
+               foreach (var user in remoteUsers.Skip(1)) {
+                  inviteString.Append($",{user.Username}");
+               }
+               result.Message = inviteString.ToString();
+            }
+            else {
+               result.Message = "No remote raiders to invite";
+            }
+
+            result.Success = true;
+         }
+         else if (raids.Count() == 0) {
+            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Could not find that raid");
+         }
+         else {
+            result.RequesterUserBuilder = EmbedBuilderHelper.ErrorBuilder("Unknown Error");
+         }
+         return result;
+      }
 
       #region Private Methods
 
 
-      private bool AddUserToRaidIfNotExists(Raid raid, IUser user, int guests) {
+      private bool AddUserToRaidIfNotExists(Raid raid, IUser user, int guests, bool isRemote) {
          if (raid.Users.Any(a => a.Equals(User.FromIUser(user)))) {
             return false;
          }
          else {
-            raid.Users.Add(User.FromIUser(user, guests));
+            raid.Users.Add(User.FromIUser(user, guests, isRemote));
             UpdateRaidWithDifferentUsers(raid);
             return true;//$"You have been added to raid: {raid.Name}";
          }
@@ -553,15 +646,18 @@ namespace RaidBot.BusinessLogic.Raids {
             result.Success = true;
 
             if (referenceUser != null) {
+               var requesterUserUsername = (requesterUser as IGuildUser).Nickname ?? requesterUser.Username;
+               var referenceUserUsername = (referenceUser as IGuildUser).Nickname ?? referenceUser.Username;
+
                result.ReferenceUserBuilder = EmbedBuilderHelper.GreenBuilder();
                result.ReferenceUserBuilder
                   .WithTitle($"Raid: {raid.Name}")
-                  .WithDescription($"You have been removed from the raid by {requesterUser.Username}");
+                  .WithDescription($"You have been removed from the raid by {requesterUserUsername}");
 
                result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();
                result.RequesterUserBuilder
                   .WithTitle($"Raid: {raid.Name}")
-                  .WithDescription($"You have removed {referenceUser.Username} from the raid");
+                  .WithDescription($"You have removed {referenceUserUsername} from the raid");
             }
             else {
                result.RequesterUserBuilder = EmbedBuilderHelper.GreenBuilder();

--- a/RaidBot/Entities/Raid.cs
+++ b/RaidBot/Entities/Raid.cs
@@ -66,16 +66,8 @@ namespace RaidBot.Entities {
          else {
             raidWithUsers.Append($"Leader: {Users.First().Username} {Users.First().GetGuests}");
 
-            List<User> inPersonUsers = new List<User>();
-            List<User> remoteUsers = new List<User>();
-
-            foreach (var user in Users) {
-               if (user.IsRemoteAttendee) {
-                  remoteUsers.Add(user);
-               } else {
-                  inPersonUsers.Add(user);
-               }
-            }
+            List<User> inPersonUsers = Users.Where(user => !user.IsRemoteAttendee).ToList();
+            List<User> remoteUsers = Users.Where(user => user.IsRemoteAttendee).ToList();
 
             if (inPersonUsers.Count() > 0) {
                raidWithUsers.Append($"\nIn person: {inPersonUsers.First().Username} {inPersonUsers.First().GetGuests}");

--- a/RaidBot/Entities/Raid.cs
+++ b/RaidBot/Entities/Raid.cs
@@ -31,6 +31,14 @@ namespace RaidBot.Entities {
          }
       }
 
+      public int RemoteUserCount
+      {
+         get {
+            List<User> remoteUsers = Users.Where(user => user.IsRemoteAttendee).ToList();
+            return remoteUsers.Count() + remoteUsers.Sum(a => a.GuestsCount);
+         }
+      }
+
       public bool Equals(Raid item) {
          return Name.Equals(item.Name, StringComparison.CurrentCultureIgnoreCase);
       }
@@ -38,7 +46,9 @@ namespace RaidBot.Entities {
       public override string ToString() {
          string time = Time?.ToString("HH:mm");
          string day = Day?.ToString("yyyy'-'MM'-'dd");
-         string result = $"{Name} {day} {time} {RaidBossName} (Expires {ToStringExpire()}) ({UserCount} attendee{(UserCount == 1 ? "" : "s")})";
+
+         string inclRemote = RemoteUserCount > 0 ? $" incl. {RemoteUserCount} remote" : "";
+         string result = $"{Name} {day} {time} {RaidBossName} (expires {ToStringExpire()}) ({UserCount} attendee{(UserCount == 1 ? "" : "s")}{inclRemote})";
          return Regex.Replace(result, @"\s+", " "); ;
       }
 
@@ -54,13 +64,31 @@ namespace RaidBot.Entities {
             raidWithUsers.Append("No users are attending this raid");
          }
          else {
-            raidWithUsers.Append($"Leader: {Users.First().Username} {Users.First().GetGuests} | ");
+            raidWithUsers.Append($"Leader: {Users.First().Username} {Users.First().GetGuests}");
 
-            foreach (var user in Users.Skip(1)) {
-               raidWithUsers.Append($"{user.Username} {user.GetGuests} | ");
+            List<User> inPersonUsers = new List<User>();
+            List<User> remoteUsers = new List<User>();
+
+            foreach (var user in Users) {
+               if (user.IsRemoteAttendee) {
+                  remoteUsers.Add(user);
+               } else {
+                  inPersonUsers.Add(user);
+               }
             }
 
-            raidWithUsers.Length -= 2;
+            if (inPersonUsers.Count() > 0) {
+               raidWithUsers.Append($"\nIn person: {inPersonUsers.First().Username} {inPersonUsers.First().GetGuests}");
+               foreach (var user in inPersonUsers.Skip(1)) {
+                  raidWithUsers.Append($" | {user.Username} {user.GetGuests}");
+               }
+            }
+            if (remoteUsers.Count() > 0) {
+               raidWithUsers.Append($"\nRemote: {remoteUsers.First().Username} {remoteUsers.First().GetGuests}");
+               foreach (var user in remoteUsers.Skip(1)) {
+                  raidWithUsers.Append($" | {user.Username} {user.GetGuests}");
+               }
+            }
          }
 
          return raidWithUsers.ToString();

--- a/RaidBot/Entities/User.cs
+++ b/RaidBot/Entities/User.cs
@@ -12,17 +12,18 @@ namespace RaidBot.Entities {
       public string Mention { get; set; }
       public string Discriminator { get; set; }
       public int GuestsCount { get; set; }
+      public bool IsRemoteAttendee { get; set; }
       public string GetGuests { get { return GuestsCount == 0 ? string.Empty : $"+{GuestsCount}"; } }
 
-      public static User FromIUser(IUser user, int guests = 0) {
+      public static User FromIUser(IUser user, int guests = 0, bool isRemote = false) {
          var guildUser = user as IGuildUser;
-         
 
          return new User() {
             Username = guildUser.Nickname?? user.Username,
             Mention = user.Mention,
             Discriminator = user.Discriminator,
             GuestsCount = guests,
+            IsRemoteAttendee = isRemote,
          };
       }
 

--- a/RaidBot/Helpers/EmbedBuilderHelper.cs
+++ b/RaidBot/Helpers/EmbedBuilderHelper.cs
@@ -11,7 +11,7 @@ namespace RaidBot.Helpers {
       public static EmbedBuilder ErrorBuilder(string errorMessage) {
          var builder = new EmbedBuilder() {
             Color = new Color(255, 0, 51),
-            Title = "The following error occured:",
+            Title = "The following error occurred:",
             Description = errorMessage,
          };
          return builder;

--- a/RaidBot/Helpers/ModuleResult.cs
+++ b/RaidBot/Helpers/ModuleResult.cs
@@ -12,5 +12,6 @@ namespace RaidBot.Helpers {
       public EmbedBuilder ReferenceUserBuilder { get; set; }
       public EmbedBuilder RequesterUserBuilder { get; set; }
       public List<User> Users { get; set; }
+      public string Message { get; set; }
    }
 }

--- a/RaidBot/Modules/HelpModule.cs
+++ b/RaidBot/Modules/HelpModule.cs
@@ -11,7 +11,7 @@ namespace RaidBot.Modules {
          _service = service;
       }
 
-      [Command("echo"), Summary("Echos a message.")]
+      [Command("echo"), Summary("Echoes a message.")]
       [Alias("say", "repeat")]
       public async Task Echo([Remainder, Summary("The text to echo")] string message) {
          var dmChannel = await Context.User.GetOrCreateDMChannelAsync();
@@ -24,10 +24,6 @@ namespace RaidBot.Modules {
          var dmChannel = await Context.User.GetOrCreateDMChannelAsync();
 
          string prefix = "$";  /* put your chosen prefix here */
-         var builder = new EmbedBuilder() {
-            Color = new Color(114, 137, 218),
-            Description = "**These are the commands you can use:**"
-         };
 
          foreach (var module in _service.Modules.OrderByDescending(a => a.Name)) /* we are now going to loop through the modules taken from the service we initiated earlier ! */
          {
@@ -49,21 +45,23 @@ namespace RaidBot.Modules {
                }
             }
 
-            if (!string.IsNullOrWhiteSpace(description)) /* if the module wasn't empty, we go and add a field where we drop all the data into! */
-            {
-               builder.AddField(x => {
-                  x.Name = module.Name;
-                  x.Value = description;
-                  x.IsInline = false;
-               });
+            if (!string.IsNullOrWhiteSpace(description)) /* if the module wasn't empty, we go and create an embed where we drop all the data into! */
+                  {
+               var builder = new EmbedBuilder() {
+                  Color = new Color(114, 137, 218),
+                  Title = $"RaidBot Commands: {module.Name}",
+                  Description = description,
+               };
+               await dmChannel.SendMessageAsync("", false, builder.Build());
             }
          }
-         builder.AddField(x => {
-            x.Name = "RaidBot Server";
-            x.Value = "Please come visit for questions, updates and testing https://discord.gg/d4KHHq8 \nIf you would like to donate, here is a link: https://www.paypal.me/RaidBot/5";
-            x.IsInline = false;
-         });
-         await dmChannel.SendMessageAsync("", false, builder.Build()); /* then we send it to the user. */
+
+         var _builder = new EmbedBuilder() {
+            Color = new Color(114, 137, 218),
+            Title = "RaidBot Server",
+            Description = "Please come visit for questions, updates and testing https://discord.gg/d4KHHq8 \nIf you would like to donate, here is a link: https://www.paypal.me/RaidBot/5",
+         };
+         await dmChannel.SendMessageAsync("", false, _builder.Build()); /* then we send it to the user. */
       }
 
    }

--- a/RaidBot/Modules/RaidModule.cs
+++ b/RaidBot/Modules/RaidModule.cs
@@ -147,14 +147,13 @@ namespace RaidBot.Modules {
          }
       }
 
-      [Command("Create"), Summary("Creates a raid")]
+      [Command("Create"), Summary("Creates a raid with the leader attending in person")]
       [Alias("Add", "New")]
-      public async Task Create(
-         [Summary("The name of the raid")] string raidName) {
+      public async Task Create([Summary("The name of the raid")] string raidName, [Summary("The time of the raid")] string raidTime, [Summary("The name or id of the raid boss")] string raidBoss, [Summary("The number of guests to add to the leader (if autojoin is set to on)")] int guests = 0) {
          var user = Context.User as IGuildUser;
 
          if (await CheckPermission(user, _serverPermissions)) {
-            var result = _raidService.CreateRaid(raidName, Context.User);
+            var result = await _raidService.CreateRaid(raidName, raidTime, raidBoss, Context.User, guests, false);
 
             if (result.Success) {
                await ReplyAsync("", false, result.RequesterUserBuilder.Build());
@@ -166,15 +165,13 @@ namespace RaidBot.Modules {
          }
       }
 
-      [Command("Create"), Summary("Creates a raid")]
-      [Alias("Add", "New")]
-      public async Task Create([Summary("The name of the raid")] string raidName, [Summary("The time of the raid")] string raidTime, [Summary("The name or id of the raid boss")] string raidBoss, [Summary("The number of guests to add to the initial attendee (if autojoin is set to on)")] int guests = 0) {
+      [Command("CreateRemote"), Summary("Creates a raid with the leader attending remotely")]
+      [Alias("AddRemote", "NewRemote")]
+      public async Task CreateRemote([Summary("The name of the raid")] string raidName, [Summary("The time of the raid")] string raidTime, [Summary("The name or id of the raid boss")] string raidBoss, [Summary("The number of guests to add to the leader (if autojoin is set to on)")] int guests = 0) {
          var user = Context.User as IGuildUser;
 
-
-
          if (await CheckPermission(user, _serverPermissions)) {
-            var result = await _raidService.CreateRaid(raidName, raidTime, raidBoss, Context.User, guests);
+            var result = await _raidService.CreateRaid(raidName, raidTime, raidBoss, Context.User, guests, true);
 
             if (result.Success) {
                await ReplyAsync("", false, result.RequesterUserBuilder.Build());
@@ -308,11 +305,11 @@ namespace RaidBot.Modules {
 
       [Command("Mode"), Summary("Changes the attendance mode for yourself or another user")]
       [Alias("Attendance")]
-      public async Task Mode([Summary("The name of the raid")] string raidName, string attendanceMode, IUser user = null) {
+      public async Task Mode([Summary("The name of the raid")] string raidName, IUser user = null) {
 
          var requesterUser = Context.User as IGuildUser;
          if (await CheckPermission(user, requesterUser, _serverPermissions)) {
-            var result = _raidService.ChangeAttendanceMode(raidName, attendanceMode, Context.User, user);
+            var result = _raidService.ChangeAttendanceMode(raidName, Context.User, user);
             var dmChannel = await requesterUser.GetOrCreateDMChannelAsync();
             await dmChannel.SendMessageAsync("", false, result.RequesterUserBuilder.Build());
             if (user != null) {


### PR DESCRIPTION
This PR adds the possibility to join a raid as a remote attendee:
- New command `$remote` or `$joinremote` allows to join a raid as a remote attendee - Example: `$remote raid1`
- `$get` displays the total number of attendees and the total number of remote attendees (as the limits for both are different)
![image](https://user-images.githubusercontent.com/645434/95530434-c3a53400-09d5-11eb-8546-0eb4b86f00c9.png)

- New command `$mode` or `$attendance` changes the attendance mode for yourself or another user - Examples: `$mode raid1 remote`, `$mode raid1 inperson`
- New command `$invites` prints the raid's invite string, a string the leader can copy-paste in-game to easily invite all remote raiders when the raid starts  (QoL feature). This command uses nicknames instead of usernames whenever nicknames are set (users can change their nickname to match their in-game name in order to make things easier for raid leaders) - Example: `$invite raid1`
- New command `$go` or `$start` or `$lobby` notifies everyone the raid is starting (QoL feature) - Example: `$go raid1`
- `$help` output was modified because, with the new commands, the embed had more characters than Discord's limit. Now, one embed per module is built and sent.